### PR TITLE
Changing to OpenShift JDK8 binary

### DIFF
--- a/.openshift/action_hooks/deploy
+++ b/.openshift/action_hooks/deploy
@@ -4,37 +4,31 @@ set -x
 
 if [ ! -d $OPENSHIFT_DATA_DIR/m2/repository ]
         then
-                cd $OPENSHIFT_DATA_DIR
-				mkdir m2/repository                
+          cd $OPENSHIFT_DATA_DIR
+				  mkdir m2/repository
 fi
 
 if [ ! -d $OPENSHIFT_DATA_DIR/logs ]
         then
-                cd $OPENSHIFT_DATA_DIR
-				mkdir logs
+          cd $OPENSHIFT_DATA_DIR
+				  mkdir logs
 fi
 
-if [ ! -d $OPENSHIFT_DATA_DIR/jdk1.8.0_20 ]
+if [ ! -d $OPENSHIFT_DATA_DIR/apache-maven-3.3.9 ]
         then
-                cd $OPENSHIFT_DATA_DIR
-                wget http://www.java.net/download/jdk8u20/archive/b17/binaries/jdk-8u20-ea-bin-b17-linux-x64-04_jun_2014.tar.gz
-                tar xvf *.tar.gz
-                rm -f *.tar.gz
-fi
-
-if [ ! -d $OPENSHIFT_DATA_DIR/apache-maven-3.3.3 ]
-        then
-                cd $OPENSHIFT_DATA_DIR
-                wget http://mirror.cc.columbia.edu/pub/software/apache/maven/maven-3/3.3.3/binaries/apache-maven-3.3.3-bin.tar.gz
-                tar xvf *.tar.gz
-                rm -f *.tar.gz
+          cd $OPENSHIFT_DATA_DIR
+          wget http://mirror.cc.columbia.edu/pub/software/apache/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz
+          tar xvf *.tar.gz
+          rm -f *.tar.gz
 fi
 
 
 cd $OPENSHIFT_REPO_DIR
-export M2=$OPENSHIFT_DATA_DIR/apache-maven-3.3.3/bin
+
+export JAVA_HOME=/etc/alternatives/java_sdk_1.8.0
+
+export M2=$OPENSHIFT_DATA_DIR/apache-maven-3.3.9/bin
 export MAVEN_OPTS="-Xms384m -Xmx412m"
-export JAVA_HOME=$OPENSHIFT_DATA_DIR/jdk1.8.0_20
 export PATH=$JAVA_HOME/bin:$M2:$PATH
 
 mvn -s settings.xml clean install

--- a/.openshift/action_hooks/start
+++ b/.openshift/action_hooks/start
@@ -4,7 +4,7 @@ source $OPENSHIFT_CARTRIDGE_SDK_BASH
 
 set -x
 
-export JAVA_HOME=$OPENSHIFT_DATA_DIR/jdk1.8.0_20
+export JAVA_HOME=/etc/alternatives/java_sdk_1.8.0
 export PATH=$JAVA_HOME/bin:$PATH
 
 cd $OPENSHIFT_REPO_DIR


### PR DESCRIPTION
OpenShift added Java 8 JDK to DIY cartrige.
This pull request is reflecting this change. No need to download JDK from www.java.net
